### PR TITLE
Added Client class with only an 'int _fd' as a private attribute (and…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,12 +30,17 @@ SERVERDIR	= $(addprefix $(SRCDIR)/,server)
 SRC_SERVER= Server.cpp
 SERVER 		= $(addprefix $(SERVERDIR)/,$(SRC_SERVER))
 
+CLIENT 		= $(addprefix $(CLIENTDIR)/,$(SRC_CLIENT))
+SRC_CLIENT= Client.cpp
+CLIENTDIR	= $(addprefix $(SRCDIR)/,client)
+
 MAINDIR		= $(addprefix $(SRCDIR)/,main)
 SRC_MAIN	= main.cpp
 MAIN 			= $(addprefix $(MAINDIR)/,$(SRC_MAIN))
 
 SRC				= $(MAIN) 	\
-						$(SERVER)
+						$(SERVER) \
+						$(CLIENT)
 
 # Object files
 OBJ 			= $(SRC:.cpp=.o)

--- a/include/Client.hpp
+++ b/include/Client.hpp
@@ -1,0 +1,17 @@
+#ifndef __CLIENT_HPP__
+# define __CLIENT_HPP__
+
+class Client {
+
+  public:
+    Client(int);
+    ~Client();
+
+    void        setSocketFd(const int&);
+    const int&  getSocketfd() const;
+
+  private:
+    int _fd;
+};
+
+#endif // __CLIENT_HPP__

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1,0 +1,14 @@
+#include "Client.hpp"
+
+Client::~Client() {}
+
+Client::Client(int fd)
+  :_fd(fd) {}
+
+void Client::setSocketFd(const int& fd) {
+    this->_fd = fd;
+}
+
+const int& Client::getSocketfd() const {
+  return this->_fd;
+}

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 
 #include "Server.hpp"
+#include "Client.hpp"
 
 int main() {
   Server* server = new Server(8080);
@@ -10,4 +11,8 @@ int main() {
   server2->print();
   delete server;
   delete server2;
+
+  Client* client = new Client(5);
+  std::cout << client->getSocketfd() << std::endl;
+  delete client;
 }


### PR DESCRIPTION
… its accessorrs)

Getter: getSocketFd -- returns const reference to the objects file descriptor attribute.

Setter: setSocketFd -- sets the objects file descriptor attribute to the integer passed as the parameter.

The Client class as of right now only has a constructor that takes an integer as argument (it will be the fd of the client).

The reason for this class is that, as of right now, I'm not sure if the client will withhold valuable information, or just its file descriptor, but just in case, to make it more scalable, I created a class for it.