### PR TITLE
Added first version of the Request class' declaration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,13 +34,18 @@ CLIENT 		= $(addprefix $(CLIENTDIR)/,$(SRC_CLIENT))
 SRC_CLIENT= Client.cpp
 CLIENTDIR	= $(addprefix $(SRCDIR)/,client)
 
+REQUEST 		= $(addprefix $(REQUESTDIR)/,$(SRC_REQUEST))
+SRC_REQUEST	= Request.cpp
+REQUESTDIR	= $(addprefix $(SRCDIR)/,request)
+
 MAINDIR		= $(addprefix $(SRCDIR)/,main)
 SRC_MAIN	= main.cpp
 MAIN 			= $(addprefix $(MAINDIR)/,$(SRC_MAIN))
 
 SRC				= $(MAIN) 	\
 						$(SERVER) \
-						$(CLIENT)
+						$(CLIENT) \
+						$(REQUEST) \
 
 # Object files
 OBJ 			= $(SRC:.cpp=.o)

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -1,0 +1,18 @@
+#ifndef __REQUEST_HPP__
+# define __REQUEST_HPP__
+
+# include <string>
+
+class Request {
+  public:
+    Request();
+    ~Request();
+
+  private:
+    std::string   _method;
+    std::string   _uri;
+    std::string   _httpVersion;
+    std::string   _queryString;
+};
+
+#endif // __REQUEST_HPP__

--- a/src/request/Request.cpp
+++ b/src/request/Request.cpp
@@ -1,0 +1,4 @@
+#include "Request.hpp"
+
+Request::Request() {}
+Request::~Request() {}


### PR DESCRIPTION
This version of the Request class has only the private attributes that can be parsed in the first non-CRLF line of the HTTP request message.
It consists of: HTTP method, the uri, the query strings and the http version.