### PR TITLE
Extened Request class and .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ webserv
 
 # Object files
 **/*.o
+
+# Stderr logs (AddressSanitizer, etc)
+
+error_log

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -8,6 +8,9 @@ class Request {
     Request();
     ~Request();
 
+    void parse(const std::string&);
+    void getRequestLine(const std::string&);
+
   private:
     std::string   _method;
     std::string   _uri;

--- a/src/request/Request.cpp
+++ b/src/request/Request.cpp
@@ -2,3 +2,11 @@
 
 Request::Request() {}
 Request::~Request() {}
+
+void Request::parse(std::string const& buffer) {
+  this->getRequestLine(buffer);
+}
+
+void Request::getRequestLine(std::string const& buffer) {
+  (void) buffer;
+}


### PR DESCRIPTION
The .gitignore file got extended by one line, a line which indicates that the file 'error_log' must be ignored.
Error_log is a file where I dump the standard error (for analyzing AddressSanitizer, for example).

On the other hand, the Request class got extended by 2 methods: parse() and getRequestLine().
The parse() method group in all of the parsing methods.
The getRequestLine() method parses the first non-CRLF line found in the HTTP request message.