### PR TITLE
Removing the test nginx container.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ webserv
 # Stderr logs (AddressSanitizer, etc)
 
 error_log
+
+# Nginx test container directory
+nginx


### PR DESCRIPTION
The nginx directory will be removed from the master branch. This is due to the necessity of keeping the master branch clean and readable.